### PR TITLE
Remove Usages of ZIO.succeedNow

### DIFF
--- a/zio-profiling/src/main/scala/zio/profiling/causal/CausalProfiler.scala
+++ b/zio-profiling/src/main/scala/zio/profiling/causal/CausalProfiler.scala
@@ -90,7 +90,7 @@ final case class CausalProfiler(
           .flatMap(
             _.fold(
               _ => ZIO.dieMessage("Program completed before profiler could collect sufficient data"),
-              ZIO.succeedNow(_)
+              ZIO.succeed(_)
             )
           )
       }


### PR DESCRIPTION
This is an internal API and will be deleted.